### PR TITLE
fix: sort leaves by their hashes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ let mut leaves = Vec::new();
 for i in 0..num_leaves {
     leaves.push(i.to_string());
 }
-let tree = StandardMerkleTree::of(leaves.clone());
+let tree = StandardMerkleTree::of_sorted(leaves.clone());
 
 for leaf in leaves.iter() {
     let proof = tree.get_proof(leaf);

--- a/src/standard_binary_tree.rs
+++ b/src/standard_binary_tree.rs
@@ -368,8 +368,10 @@ mod test {
 
         let tree = StandardMerkleTree::of_sorted(&leaves);
 
-        assert_eq!(
-            tree.get_proof(&leaves.get(0).unwrap()).unwrap(),
+        let proof = tree.get_proof(leaves.first().unwrap()).unwrap();
+        let is_valid = tree.verify_proof(leaves.first().unwrap(), proof.clone());
+        assert!(is_valid);
+        assert_eq!(proof,
             vec![
                 hex!("8ee56d16226ff6684927054c33cd505c4eee1ebabbffe198460d00cb083aaebd"),
                 hex!("fa31eb8d65ff2307b7026df667a06a19aade0151ed701ed2307295ae4fa48364"),

--- a/src/standard_binary_tree.rs
+++ b/src/standard_binary_tree.rs
@@ -73,7 +73,6 @@ impl StandardMerkleTree {
         Self { tree, tree_values }
     }
 
-
     pub fn of(values: &[DynSolValue]) -> Self {
         Self::create(values, false)
     }
@@ -282,7 +281,7 @@ mod test {
     use alloc::vec;
     use alloc::vec::Vec;
     use alloy::dyn_abi::DynSolValue;
-    use alloy::primitives::{address, hex, hex::FromHex, U256, FixedBytes};
+    use alloy::primitives::{address, hex, hex::FromHex, FixedBytes, U256};
 
     /// Tests the [`StandardMerkleTree`] with string-type leaves.
     #[test]
@@ -371,7 +370,8 @@ mod test {
         let proof = tree.get_proof(leaves.first().unwrap()).unwrap();
         let is_valid = tree.verify_proof(leaves.first().unwrap(), proof.clone());
         assert!(is_valid);
-        assert_eq!(proof,
+        assert_eq!(
+            proof,
             vec![
                 hex!("8ee56d16226ff6684927054c33cd505c4eee1ebabbffe198460d00cb083aaebd"),
                 hex!("fa31eb8d65ff2307b7026df667a06a19aade0151ed701ed2307295ae4fa48364"),


### PR DESCRIPTION
This PR fixes the implementation of the standard tree by sorting the leaves by their hashes. Test included.

For reference this is implemented in the openzeppelin implementation here: https://github.com/OpenZeppelin/merkle-tree/blob/master/src/merkletree.ts#L69-L71