### PR TITLE
refactor: eliminate OpenSSL dependencies by replacing alloy meta crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.7.3"
 edition = "2021"
 
 [dependencies]
-alloy = { version = "1.0", features = ["dyn-abi"] }
+alloy-primitives = "1.2"
+alloy-dyn-abi = "1.2"
 hashbrown = "0.15.3"
 anyhow = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]

--- a/src/incremental_tree.rs
+++ b/src/incremental_tree.rs
@@ -2,7 +2,7 @@
 //! used in the [ETH2 Deposit Contract](https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa).
 
 use alloc::{vec, vec::Vec};
-use alloy::primitives::{keccak256, B256};
+use alloy_primitives::{keccak256, B256};
 
 /// The error type for the [IncrementalMerkleTree].
 #[derive(Debug)]
@@ -208,7 +208,7 @@ impl<const HEIGHT: usize> IncrementalMerkleTree<HEIGHT> {
 #[cfg(test)]
 mod test {
     use super::IncrementalMerkleTree;
-    use alloy::primitives::{keccak256, B256};
+    use alloy_primitives::{keccak256, B256};
 
     #[test]
     fn test_static_tree_root() {

--- a/src/standard_binary_tree.rs
+++ b/src/standard_binary_tree.rs
@@ -6,7 +6,7 @@
 //!
 //! ```rust
 //! use alloy_merkle_tree::standard_binary_tree::StandardMerkleTree;
-//! use alloy::dyn_abi::DynSolValue;
+//! use alloy_dyn_abi::DynSolValue;
 //!
 //! let num_leaves = 1000;
 //! let mut leaves = Vec::new();
@@ -28,8 +28,8 @@ use crate::alloc::string::ToString;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloy::dyn_abi::DynSolValue;
-use alloy::primitives::{keccak256, Keccak256, B256};
+use alloy_dyn_abi::DynSolValue;
+use alloy_primitives::{keccak256, Keccak256, B256};
 
 use hashbrown::HashMap;
 
@@ -280,8 +280,8 @@ mod test {
     use alloc::string::String;
     use alloc::vec;
     use alloc::vec::Vec;
-    use alloy::dyn_abi::DynSolValue;
-    use alloy::primitives::{address, hex, hex::FromHex, FixedBytes, U256};
+    use alloy_dyn_abi::DynSolValue;
+    use alloy_primitives::{address, hex, hex::FromHex, FixedBytes, U256};
 
     /// Tests the [`StandardMerkleTree`] with string-type leaves.
     #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust
 //! use alloy_merkle_tree::tree::MerkleTree;
-//! use alloy::primitives::{B256, U256};
+//! use alloy_primitives::{B256, U256};
 //!
 //! let mut tree = MerkleTree::new();
 //! // Number of leaves should be a power of 2 for a perfect binary tree
@@ -22,7 +22,7 @@
 //!
 
 use alloc::vec::Vec;
-use alloy::primitives::{Keccak256, B256};
+use alloy_primitives::{Keccak256, B256};
 
 /// Represents a Merkle proof for a specific leaf in the Merkle tree.
 #[derive(Debug)]
@@ -206,7 +206,7 @@ impl MerkleTree {
 #[cfg(test)]
 mod test {
     use crate::tree::MerkleTree;
-    use alloy::primitives::{B256, U256};
+    use alloy_primitives::{B256, U256};
 
     /// Tests the basic functionality of the [`MerkleTree`].
     #[test]


### PR DESCRIPTION
## Summary

This PR eliminates OpenSSL dependencies from the alloy-merkle-tree crate by replacing the heavyweight `alloy` meta crate with minimal specific dependencies. The crate now uses only the cryptographic primitives needed for merkle tree operations.

## Changes

- **Dependency optimization**: Replace `alloy` meta crate with `alloy-primitives` and `alloy-dyn-abi`
- **Import updates**: Update all import paths from `alloy::*` to `alloy_*`
- **Toolchain update**: Bump Rust toolchain to 1.85 (required for alloy 1.2)

## Impact

**Before**: 640 dependencies including reqwest, hyper-tls, native-tls, and OpenSSL
**After**: 93 dependencies (85% reduction) with zero OpenSSL/TLS dependencies

The crate now contains only:
- `alloy-primitives` 1.2: B256, U256, Keccak256, keccak256(), address\!(), hex
- `alloy-dyn-abi` 1.2: DynSolValue

## Testing

✅ All 9 unit tests pass
✅ All 2 documentation tests pass  
✅ Verified no OpenSSL dependencies in dependency tree
✅ Identical merkle tree functionality preserved

This change significantly reduces the attack surface, compilation time, and binary size for projects depending on this crate while maintaining 100% functional compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>